### PR TITLE
ITOS-131: Use dafault date if date_created is to old

### DIFF
--- a/etl/dhis-reports/report_scripts/dashboard_event.sql
+++ b/etl/dhis-reports/report_scripts/dashboard_event.sql
@@ -382,8 +382,13 @@ BEGIN
             COUNT(p.patient_id) AS grandTotal, -- Totaux généraux
             version.value_reference -- Version
           FROM isanteplus.tmp_idgen tmp,
-            ( SELECT location_id, MIN(date_created) oldestDate, MAX(date_created) latestDate
-              FROM `openmrs`.obs
+            ( SELECT location_id, 
+				CASE
+					WHEN MIN(date_created) < DATE('2005-04-08') OR MIN(date_created) > CURDATE() THEN DATE('2005-04-08')
+					ELSE MIN(date_created)
+				END AS oldestDate, 
+				MAX(date_created) latestDate
+              FROM `openmrs`.encounter
               GROUP BY location_id ) AS dates,
             patient p
             LEFT OUTER JOIN ( SELECT l.location_id, l.value_reference

--- a/etl/dhis-reports/report_scripts/dashboard_tracked_entity.sql
+++ b/etl/dhis-reports/report_scripts/dashboard_tracked_entity.sql
@@ -272,8 +272,13 @@ BEGIN
             COUNT(p.patient_id) AS grandTotal, -- Totaux généraux
             version.value_reference -- Version
           FROM isanteplus.tmp_idgen tmp,
-            ( SELECT location_id, MIN(date_created) oldestDate, MAX(date_created) latestDate
-              FROM `openmrs`.obs
+            ( SELECT location_id, 
+				CASE
+					WHEN MIN(date_created) < DATE('2005-04-08') OR MIN(date_created) > CURDATE() THEN DATE('2005-04-08')
+					ELSE MIN(date_created)
+				END AS oldestDate, 
+				MAX(date_created) latestDate
+              FROM `openmrs`.encounter
               GROUP BY location_id ) AS dates,
             patient p
             LEFT OUTER JOIN ( SELECT l.location_id, l.value_reference


### PR DESCRIPTION
If date_created in encouter table is less than 8th April 2005
or greater than current date then we should use this date as default